### PR TITLE
feat: Support running composite action both in PRs or pushes (#4)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -117,12 +117,13 @@ This project uses [Semantic Versioning](https://semver.org/). The version number
 
 ## Release process
 
-Once the PR is approved and merged into the main branch, a project maintainer can start the release process by:
+Once the PR is approved and __merged into the release branch__, a project maintainer can start the release process by:
 
 1. Updating the version number in the `package.json` file.
 2. Updating the action version in the `.github/actions/check-and-comment/action.yml` file.
 3. Updating the CHANGELOG.md file with the changes in the new version.
 4. Tagging the main branch with the corresponding version numbers.
+5. Merge the release branch into the main branch.
 
 This project includes a helper script, [`script/release`](./script/release)
 designed to streamline the process of tagging and pushing new releases for

--- a/.github/actions/check-and-comment/action.yml
+++ b/.github/actions/check-and-comment/action.yml
@@ -53,6 +53,7 @@ runs:
         reporter: 'markdown'
     - name: Find Comment
       uses: peter-evans/find-comment@v3
+      if: ${{ github.event_name == 'pull_request' }}
       id: previous-comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -60,6 +61,7 @@ runs:
         body-includes: Check SPDX headers
     - name: Create or update comment
       uses: peter-evans/create-or-update-comment@v4
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         comment-id: ${{ steps.previous-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,7 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN_XCUT }}
 
       - name: Check License Compliance
-        if: github.event_name != 'pull_request'
-        uses: Telefonica/check-license-compliance@v0.1.0
-
-      - name: Check License Compliance
-        if: github.event_name == 'pull_request'
-        uses: Telefonica/check-license-compliance/.github/actions/check-and-comment@v0.1.0
+        uses: Telefonica/check-license-compliance/.github/actions/check-and-comment@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   check-spdx-headers:
@@ -113,11 +108,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check SPDX headers
-        if: github.event_name != 'pull_request'
-        uses: ./
-
-      - name: Check SPDX headers
-        if: github.event_name == 'pull_request'
         uses: ./.github/actions/check-and-comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+## [0.2.0] - 2025-01
+
+### Added
+
+* feat: Support running composite action both in PRs or pushes. In pushes, the action won't send any comment
+
+### Fixed
+
+* chore: Pin chalk dependency
+
+
 ## [0.1.0] - 2024-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@tid-xcut/check-spdx-headers",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tid-xcut/check-spdx-headers",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "1.11.1",
-        "chalk": "^5.3.0",
+        "chalk": "5.3.0",
         "glob": "11.0.0",
         "indent-string": "5.0.0",
         "spdx-satisfies": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tid-xcut/check-spdx-headers",
   "description": "Checks that files have the correct SPDX headers",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Telefónica Innovación Digital",
   "homepage": "https://github.com/Telefonica/check-spdx-headers",
   "repository": {
@@ -35,7 +35,7 @@
     "cspell": "cspell . ./.github/**/*.md",
     "lint": "eslint .",
     "lint:staged": "lint-staged",
-    "local-action": "local-action . dist/index.ts .env",
+    "local-action": "local-action . src/main.ts .env",
     "package": "ncc build src/index.ts --transpile-only -o dist --source-map --license licenses.txt && node ./script/post-package.js",
     "prepare": "husky",
     "test:e2e": "jest --config jest.e2e.config.js",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "1.11.1",
-    "chalk": "^5.3.0",
+    "chalk": "5.3.0",
     "glob": "11.0.0",
     "indent-string": "5.0.0",
     "spdx-satisfies": "5.0.1",


### PR DESCRIPTION
# Support running composite action both in PRs or pushes

## Description

### Added

* feat: Support running composite action both in PRs or pushes. In pushes, the action won't send any comment

### Fixed

* chore: Pin chalk dependency

## Agreement

Please check the following boxes after you have read and understood each item.

* [ ] I have read the [CONTRIBUTING](https://github.com/Telefonica/check-spdx-headers/blob/main/.github/CONTRIBUTING.md) document
* [ ] I have read the [CODE_OF_CONDUCT](https://github.com/Telefonica/check-spdx-headers/blob/main/.github/CODE_OF_CONDUCT.md) document
* [ ] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
